### PR TITLE
fix study list hyperlink issue

### DIFF
--- a/src/pages/studies/studiesView.js
+++ b/src/pages/studies/studiesView.js
@@ -7,10 +7,13 @@ import { CustomDataTable, getOptions, getColumns } from 'bento-components';
 import {
   pageData,
 } from '../../bento/studiesData';
+import filterCasePageOnStudyCode from '../../utils/utils';
 
 const Studies = ({ classes, data }) => {
   // TBD
-  const redirectTo = '';
+  const redirectTo = (study) => {
+    filterCasePageOnStudyCode(study.rowData[0]);
+  };
 
   return (
     <>


### PR DESCRIPTION
fix the issue from the Cases count hyperlink in the Study Listing page. Cases count hyperlink is not funcitonal when clicked. 