### PR TITLE
ICDC-2745: update model-explorer to v0.0.55

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "line-awesome": "github:icons8/line-awesome",
         "lodash": "^4.17.20",
         "mini-css-extract-plugin": "0.5.0",
-        "model-explorer": "^0.0.54",
+        "model-explorer": "^0.0.55",
         "optimize-css-assets-webpack-plugin": "5.0.1",
         "pnp-webpack-plugin": "1.2.1",
         "postcss-flexbugs-fixes": "4.1.0",
@@ -21461,9 +21461,9 @@
       }
     },
     "node_modules/model-explorer": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/model-explorer/-/model-explorer-0.0.54.tgz",
-      "integrity": "sha512-REMZtzHf0QvKZhCJNlBema3/cN2lshx9S0A2BFYIoTrSbkxCjdz5XXnmRPNoV8Siu8RDopflP4zxt+Jbx9d6lg==",
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/model-explorer/-/model-explorer-0.0.55.tgz",
+      "integrity": "sha512-EEYV3R0BAt5OZveQQ0av8SBArJOX2BbsxbeR/f84HAkMEgXKpDMef2pQsboeFfxEXKms92OYXL8opQU7ElIcKg==",
       "dependencies": {
         "@apollo/client": "^3.3.4",
         "@apollo/react-components": "^4.0.0",
@@ -52044,9 +52044,9 @@
       "requires": {}
     },
     "model-explorer": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/model-explorer/-/model-explorer-0.0.54.tgz",
-      "integrity": "sha512-REMZtzHf0QvKZhCJNlBema3/cN2lshx9S0A2BFYIoTrSbkxCjdz5XXnmRPNoV8Siu8RDopflP4zxt+Jbx9d6lg==",
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/model-explorer/-/model-explorer-0.0.55.tgz",
+      "integrity": "sha512-EEYV3R0BAt5OZveQQ0av8SBArJOX2BbsxbeR/f84HAkMEgXKpDMef2pQsboeFfxEXKms92OYXL8opQU7ElIcKg==",
       "requires": {
         "@apollo/client": "^3.3.4",
         "@apollo/react-components": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "line-awesome": "github:icons8/line-awesome",
     "lodash": "^4.17.20",
     "mini-css-extract-plugin": "0.5.0",
-    "model-explorer": "^0.0.54",
+    "model-explorer": "^0.0.55",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "pnp-webpack-plugin": "1.2.1",
     "postcss-flexbugs-fixes": "4.1.0",


### PR DESCRIPTION
<!--
- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features
End User downloads a File Transfer Manifest template

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
