### PR TITLE
add drafts of study details queries (ICDC-3053)

### DIFF
--- a/graphql/icdc-doc.graphql
+++ b/graphql/icdc-doc.graphql
@@ -1,21 +1,21 @@
 type adverse_event {
-  ae_dose: Float
-  ae_dose_unit: String
-  ae_dose_original: Float
-  ae_dose_original_unit: String
-  ae_agent_name: String
   day_in_cycle: Int
-  date_resolved: String
+  date_of_onset: String
+  existing_adverse_event: String
+  date_of_resolution: String
+  ongoing_adverse_event: String
   adverse_event_term: String
   adverse_event_description: String
   adverse_event_grade: String
   adverse_event_grade_description: String
+  adverse_event_agent_name: String
+  adverse_event_agent_dose: String
   attribution_to_research: String
   attribution_to_ind: String
   attribution_to_disease: String
   attribution_to_commercial: String
   attribution_to_other: String
-  ae_other: String
+  other_attribution_description: String
   dose_limiting_toxicity: String
   unexpected_adverse_event: String
   case: case 
@@ -127,7 +127,9 @@ type cycle {
 }
 
 type demographic {
+  demographic_id: String
   breed: String
+  additional_breed_detail: String
   patient_age_at_enrollment: Float
   patient_age_at_enrollment_unit: String
   patient_age_at_enrollment_original: Float
@@ -143,6 +145,7 @@ type demographic {
 }
 
 type diagnosis {
+  diagnosis_id: String
   disease_term: String
   primary_disease_site: String
   stage_of_disease: String
@@ -156,7 +159,6 @@ type diagnosis {
   follow_up_data: String
   concurrent_disease: String
   concurrent_disease_type: String
-  diagnosis_id: String
   case: case 
   files: [file] 
 }
@@ -181,6 +183,7 @@ type disease_extent {
 }
 
 type enrollment {
+  enrollment_id: String
   date_of_registration: String
   registering_institution: String
   initials: String
@@ -188,7 +191,6 @@ type enrollment {
   site_short_name: String
   veterinary_medical_center: String
   patient_subgroup: String
-  enrollment_id: String
   case: case 
   prior_therapies: [prior_therapy] 
   prior_surgeries: [prior_surgery] 
@@ -861,6 +863,23 @@ type UnifiedCounts{
     volumeOfData: Float
 }
 
+type ClinicalDataNodeCounts {
+    agent: Int,
+    cycle: Int,
+    visit: Int,
+    follow_up: Int,
+    adverse_event: Int,
+    off_treatment: Int,
+    off_study: Int,
+    prior_therapy: Int,
+    prior_surgery: Int,
+    agent_administration: Int,
+    physical_exam: Int,
+    vital_signs: Int,
+    disease_extent: Int,
+    lab_exam: Int
+}
+
 type QueryType {
     "Version"
     schemaVersion: String 
@@ -952,5 +971,11 @@ type QueryType {
     studySampleTypeCount(study_codes: [String]): [GroupCount] 
 
     studySamplePathologyCount(study_codes: [String]): [GroupCount] 
+
+    clinicalDataNodeCounts(study_code: String!): ClinicalDataNodeCounts 
+
+    clinicalDataNodeCaseCounts(study_code: String!): ClinicalDataNodeCounts 
+
+    clinicalDataNodeNames: [String] 
 }
 

--- a/graphql/icdc.graphql
+++ b/graphql/icdc.graphql
@@ -1,21 +1,21 @@
 type adverse_event {
-  ae_dose: Float
-  ae_dose_unit: String
-  ae_dose_original: Float
-  ae_dose_original_unit: String
-  ae_agent_name: String
   day_in_cycle: Int
-  date_resolved: String
+  date_of_onset: String
+  existing_adverse_event: String
+  date_of_resolution: String
+  ongoing_adverse_event: String
   adverse_event_term: String
   adverse_event_description: String
   adverse_event_grade: String
   adverse_event_grade_description: String
+  adverse_event_agent_name: String
+  adverse_event_agent_dose: String
   attribution_to_research: String
   attribution_to_ind: String
   attribution_to_disease: String
   attribution_to_commercial: String
   attribution_to_other: String
-  ae_other: String
+  other_attribution_description: String
   dose_limiting_toxicity: String
   unexpected_adverse_event: String
   case: case @relation(name:"of_case", direction:OUT)
@@ -127,7 +127,9 @@ type cycle {
 }
 
 type demographic {
+  demographic_id: String
   breed: String
+  additional_breed_detail: String
   patient_age_at_enrollment: Float
   patient_age_at_enrollment_unit: String
   patient_age_at_enrollment_original: Float
@@ -143,6 +145,7 @@ type demographic {
 }
 
 type diagnosis {
+  diagnosis_id: String
   disease_term: String
   primary_disease_site: String
   stage_of_disease: String
@@ -156,7 +159,6 @@ type diagnosis {
   follow_up_data: String
   concurrent_disease: String
   concurrent_disease_type: String
-  diagnosis_id: String
   case: case @relation(name:"of_case", direction:OUT)
   files: [file] @relation(name:"from_diagnosis", direction:IN)
 }
@@ -181,6 +183,7 @@ type disease_extent {
 }
 
 type enrollment {
+  enrollment_id: String
   date_of_registration: String
   registering_institution: String
   initials: String
@@ -188,7 +191,6 @@ type enrollment {
   site_short_name: String
   veterinary_medical_center: String
   patient_subgroup: String
-  enrollment_id: String
   case: case @relation(name:"of_case", direction:OUT)
   prior_therapies: [prior_therapy] @relation(name:"at_enrollment", direction:IN)
   prior_surgeries: [prior_surgery] @relation(name:"at_enrollment", direction:IN)
@@ -859,6 +861,23 @@ type UnifiedCounts{
     numberOfPrograms: Int
     numberOfAliquots: Int
     volumeOfData: Float
+}
+
+type ClinicalDataNodeCounts {
+    agent: Int,
+    cycle: Int,
+    visit: Int,
+    follow_up: Int,
+    adverse_event: Int,
+    off_treatment: Int,
+    off_study: Int,
+    prior_therapy: Int,
+    prior_surgery: Int,
+    agent_administration: Int,
+    physical_exam: Int,
+    vital_signs: Int,
+    disease_extent: Int,
+    lab_exam: Int
 }
 
 type QueryType {
@@ -1658,5 +1677,99 @@ type QueryType {
     }
     ORDER BY group
     """, passThrough: true)
+
+    clinicalDataNodeCounts(study_code: String!): ClinicalDataNodeCounts @cypher(statement: """
+    MATCH (s:study)
+    WHERE s.clinical_study_designation = $study_code
+    OPTIONAL MATCH (sa:study_arm)<-[:of_study_arm]-(a:agent)
+    OPTIONAL MATCH (s)<-[*1..2]-(c:case)
+    OPTIONAL MATCH (c)<-[:of_case]-(cy:cycle)
+    OPTIONAL MATCH (c)<-[*1..2]-(v:visit)
+    OPTIONAL MATCH (c)<-[:of_case]-(fu:follow_up)
+    OPTIONAL MATCH (c)<-[:of_case]-(ae:adverse_event)
+    OPTIONAL MATCH (c)<-[:of_case]-(e:enrollment)
+    OPTIONAL MATCH (c)-[:went_off_treatment]->(ot:off_treatment)
+    OPTIONAL MATCH (c)-[:went_off_study]->(os:off_study)
+    OPTIONAL MATCH (e)<-[:at_enrollment]-(pt:prior_therapy)
+    OPTIONAL MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
+    OPTIONAL MATCH (v)<-[:on_visit]-(aa:agent_administration)
+    OPTIONAL MATCH (v)<-[:on_visit]-(pe:physical_exam)
+    OPTIONAL MATCH (v)<-[:on_visit]-(vs:vital_signs)
+    OPTIONAL MATCH (v)<-[:on_visit]-(de:disease_extent)
+    OPTIONAL MATCH (v)<-[:on_visit]-(le:lab_exam)
+    RETURN {
+        agent: COUNT(DISTINCT a),
+        cycle: COUNT(DISTINCT cy),
+        visit: COUNT(DISTINCT v),
+        follow_up: COUNT(DISTINCT fu),
+        adverse_event: COUNT(DISTINCT ae),
+        off_treatment: COUNT(DISTINCT ot),
+        off_study: COUNT(DISTINCT os),
+        prior_therapy: COUNT(DISTINCT pt),
+        prior_surgery: COUNT(DISTINCT ps),
+        agent_administration: COUNT(DISTINCT aa),
+        physical_exam: COUNT(DISTINCT pe),
+        vital_signs: COUNT(DISTINCT vs),
+        disease_extent: COUNT(DISTINCT de),
+        lab_exam: COUNT(DISTINCT le)
+    }
+    """)
+
+    clinicalDataNodeCaseCounts(study_code: String!): ClinicalDataNodeCounts @cypher(statement: """
+    MATCH (s:study)
+    WHERE s.clinical_study_designation = $study_code
+    OPTIONAL MATCH (sa:study_arm)<-[:of_study_arm]-(a:agent)
+    OPTIONAL MATCH (s)<-[*1..2]-(c:case)
+    OPTIONAL MATCH (c)<-[:of_case]-(cy:cycle)
+    OPTIONAL MATCH (c)<-[*1..2]-(v:visit)
+    OPTIONAL MATCH (c)<-[:of_case]-(fu:follow_up)
+    OPTIONAL MATCH (c)-[:had_adverse_event]->(ae:adverse_event)
+    OPTIONAL MATCH (c)<-[:of_case]-(e:enrollment)
+    OPTIONAL MATCH (c)-[:went_off_treatment]->(ot:off_treatment)
+    OPTIONAL MATCH (c)-[:went_off_study]->(os:off_study)
+    OPTIONAL MATCH (e)<-[:at_enrollment]-(pt:prior_therapy)
+    OPTIONAL MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
+    OPTIONAL MATCH (v)<-[:on_visit]-(aa:agent_administration)
+    OPTIONAL MATCH (v)<-[:on_visit]-(pe:physical_exam)
+    OPTIONAL MATCH (v)<-[:on_visit]-(vs:vital_signs)
+    OPTIONAL MATCH (v)<-[:on_visit]-(de:disease_extent)
+    OPTIONAL MATCH (v)<-[:on_visit]-(le:lab_exam)
+    RETURN {
+        agent: COUNT(DISTINCT a),
+        cycle: COUNT(DISTINCT cy.case_id),
+        visit: COUNT(DISTINCT left(v.visit_id, 13)),
+        follow_up: COUNT(DISTINCT fu),
+        adverse_event: COUNT(DISTINCT ae),
+        off_treatment: COUNT(DISTINCT ot),
+        off_study: COUNT(DISTINCT os),
+        prior_therapy: COUNT(DISTINCT pt),
+        prior_surgery: COUNT(DISTINCT ps),
+        agent_administration: COUNT(DISTINCT aa),
+        physical_exam: COUNT(DISTINCT pe.case_id),
+        vital_signs: COUNT(DISTINCT vs.case_id),
+        disease_extent: COUNT(DISTINCT de.case_id),
+        lab_exam: COUNT(DISTINCT le)
+    }
+    """)
+
+    clinicalDataNodeNames: [String] @cypher(statement: """
+    UNWIND [
+        'AGENT',
+        'CYCLE',
+        'VISIT',
+        'PRIOR THERAPY',
+        'PRIOR SURGERY',
+        'AGENT ADMINISTRATION',
+        'PHYSICAL EXAM',
+        'VITAL SIGNS',
+        'LAB EXAM',
+        'ADVERSE EVENT',
+        'DISEASE EXTENT',
+        'FOLLOW UP',
+        'OFF STUDY',
+        'OFF TREATMENT'
+    ] AS clinical_data_node_names
+    RETURN clinical_data_node_names
+    """)
 }
 

--- a/graphql/icdc_queries.graphql
+++ b/graphql/icdc_queries.graphql
@@ -372,6 +372,23 @@ type UnifiedCounts{
     volumeOfData: Float
 }
 
+type ClinicalDataNodeCounts {
+    agent: Int,
+    cycle: Int,
+    visit: Int,
+    follow_up: Int,
+    adverse_event: Int,
+    off_treatment: Int,
+    off_study: Int,
+    prior_therapy: Int,
+    prior_surgery: Int,
+    agent_administration: Int,
+    physical_exam: Int,
+    vital_signs: Int,
+    disease_extent: Int,
+    lab_exam: Int
+}
+
 type QueryType {
     "Version"
     schemaVersion: String @cypher(statement: "RETURN '2.0.0'")
@@ -1169,5 +1186,99 @@ type QueryType {
     }
     ORDER BY group
     """, passThrough: true)
+
+    clinicalDataNodeCounts(study_code: String!): ClinicalDataNodeCounts @cypher(statement: """
+    MATCH (s:study)
+    WHERE s.clinical_study_designation = $study_code
+    OPTIONAL MATCH (sa:study_arm)<-[:of_study_arm]-(a:agent)
+    OPTIONAL MATCH (s)<-[*1..2]-(c:case)
+    OPTIONAL MATCH (c)<-[:of_case]-(cy:cycle)
+    OPTIONAL MATCH (c)<-[*1..2]-(v:visit)
+    OPTIONAL MATCH (c)<-[:of_case]-(fu:follow_up)
+    OPTIONAL MATCH (c)<-[:of_case]-(ae:adverse_event)
+    OPTIONAL MATCH (c)<-[:of_case]-(e:enrollment)
+    OPTIONAL MATCH (c)-[:went_off_treatment]->(ot:off_treatment)
+    OPTIONAL MATCH (c)-[:went_off_study]->(os:off_study)
+    OPTIONAL MATCH (e)<-[:at_enrollment]-(pt:prior_therapy)
+    OPTIONAL MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
+    OPTIONAL MATCH (v)<-[:on_visit]-(aa:agent_administration)
+    OPTIONAL MATCH (v)<-[:on_visit]-(pe:physical_exam)
+    OPTIONAL MATCH (v)<-[:on_visit]-(vs:vital_signs)
+    OPTIONAL MATCH (v)<-[:on_visit]-(de:disease_extent)
+    OPTIONAL MATCH (v)<-[:on_visit]-(le:lab_exam)
+    RETURN {
+        agent: COUNT(DISTINCT a),
+        cycle: COUNT(DISTINCT cy),
+        visit: COUNT(DISTINCT v),
+        follow_up: COUNT(DISTINCT fu),
+        adverse_event: COUNT(DISTINCT ae),
+        off_treatment: COUNT(DISTINCT ot),
+        off_study: COUNT(DISTINCT os),
+        prior_therapy: COUNT(DISTINCT pt),
+        prior_surgery: COUNT(DISTINCT ps),
+        agent_administration: COUNT(DISTINCT aa),
+        physical_exam: COUNT(DISTINCT pe),
+        vital_signs: COUNT(DISTINCT vs),
+        disease_extent: COUNT(DISTINCT de),
+        lab_exam: COUNT(DISTINCT le)
+    }
+    """)
+
+    clinicalDataNodeCaseCounts(study_code: String!): ClinicalDataNodeCounts @cypher(statement: """
+    MATCH (s:study)
+    WHERE s.clinical_study_designation = $study_code
+    OPTIONAL MATCH (sa:study_arm)<-[:of_study_arm]-(a:agent)
+    OPTIONAL MATCH (s)<-[*1..2]-(c:case)
+    OPTIONAL MATCH (c)<-[:of_case]-(cy:cycle)
+    OPTIONAL MATCH (c)<-[*1..2]-(v:visit)
+    OPTIONAL MATCH (c)<-[:of_case]-(fu:follow_up)
+    OPTIONAL MATCH (c)-[:had_adverse_event]->(ae:adverse_event)
+    OPTIONAL MATCH (c)<-[:of_case]-(e:enrollment)
+    OPTIONAL MATCH (c)-[:went_off_treatment]->(ot:off_treatment)
+    OPTIONAL MATCH (c)-[:went_off_study]->(os:off_study)
+    OPTIONAL MATCH (e)<-[:at_enrollment]-(pt:prior_therapy)
+    OPTIONAL MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
+    OPTIONAL MATCH (v)<-[:on_visit]-(aa:agent_administration)
+    OPTIONAL MATCH (v)<-[:on_visit]-(pe:physical_exam)
+    OPTIONAL MATCH (v)<-[:on_visit]-(vs:vital_signs)
+    OPTIONAL MATCH (v)<-[:on_visit]-(de:disease_extent)
+    OPTIONAL MATCH (v)<-[:on_visit]-(le:lab_exam)
+    RETURN {
+        agent: COUNT(DISTINCT a),
+        cycle: COUNT(DISTINCT cy.case_id),
+        visit: COUNT(DISTINCT left(v.visit_id, 13)),
+        follow_up: COUNT(DISTINCT fu),
+        adverse_event: COUNT(DISTINCT ae),
+        off_treatment: COUNT(DISTINCT ot),
+        off_study: COUNT(DISTINCT os),
+        prior_therapy: COUNT(DISTINCT pt),
+        prior_surgery: COUNT(DISTINCT ps),
+        agent_administration: COUNT(DISTINCT aa),
+        physical_exam: COUNT(DISTINCT pe.case_id),
+        vital_signs: COUNT(DISTINCT vs.case_id),
+        disease_extent: COUNT(DISTINCT de.case_id),
+        lab_exam: COUNT(DISTINCT le)
+    }
+    """)
+
+    clinicalDataNodeNames: [String] @cypher(statement: """
+    UNWIND [
+        'AGENT',
+        'CYCLE',
+        'VISIT',
+        'PRIOR THERAPY',
+        'PRIOR SURGERY',
+        'AGENT ADMINISTRATION',
+        'PHYSICAL EXAM',
+        'VITAL SIGNS',
+        'LAB EXAM',
+        'ADVERSE EVENT',
+        'DISEASE EXTENT',
+        'FOLLOW UP',
+        'OFF STUDY',
+        'OFF TREATMENT'
+    ] AS clinical_data_node_names
+    RETURN clinical_data_node_names
+    """)
 }
 


### PR DESCRIPTION
<!--
- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features

JIRA ticket: https://tracker.nci.nih.gov/browse/ICDC-3053

added `clinicalDataNodeCounts`, `clinicalDataNodeCaseCounts` and `clinicalDataNodeNames` queries

**These nodes don't appear to have data in them on DEV/QA:**
- agent
- follow_up
- agent_administration
- lab_exam
- prior_therapy
- off_treatment
- off_study

Is `had_adverse_event` relationship between `case` and `adverse_event` nodes being used?
- this seems like the easiest/most direct way to get the number of cases having adverse events

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
