### PR TITLE
ICDC-4027(feat): remove banner text in Announcements section

### DIFF
--- a/src/pages/landing/views/newsView.tsx
+++ b/src/pages/landing/views/newsView.tsx
@@ -443,19 +443,19 @@ const NewsView = ({
 
             <NewsListTitleBar>
               <NewsListTitle>
-                <h6
-                  style={{
-                    color: 'white',
-                    fontSize: '1.8em',
-                    fontWeight: '900',
-                    margin: 0,
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.05em',
-                    fontFamily: 'Raleway',
-                  }}
-                >
-                  Updates
-                </h6>
+                {/* <h6 */}
+                {/*   style={{ */}
+                {/*     color: 'white', */}
+                {/*     fontSize: '1.8em', */}
+                {/*     fontWeight: '900', */}
+                {/*     margin: 0, */}
+                {/*     textTransform: 'uppercase', */}
+                {/*     letterSpacing: '0.05em', */}
+                {/*     fontFamily: 'Raleway', */}
+                {/*   }} */}
+                {/* > */}
+                {/*   Updates */}
+                {/* </h6> */}
               </NewsListTitle>
               <NewsList>
                 {newsContent.map((item: any, index: number) => (


### PR DESCRIPTION
 Removes the hard-coded “Updates” banner text from the landing page Announcements section.

  ### New Features

  N/A

  ### Breaking Changes

  N/A

  ### Bug Fixes

  N/A

  ### Improvements

  - Hides the “Updates” heading from the Announcements section title bar on the landing page.

  ### Dependency updates

  N/A

  ### Deployment changes

  N/A